### PR TITLE
Make the snap classic

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,15 +7,11 @@ description: |
   Fast code, fast.
   This snap is maintained by Ernesto Castellotti, and is not necessarily endorsed or officially maintained by the upstream developers.
   
-confinement: strict
+confinement: classic
 grade: stable
 architectures:
   - build-on: amd64
   - build-on: i386
-
-environment:
-  PATH: $PATH:$SNAP/usr/bin
-  CC: $SNAP/usr/bin/gcc --sysroot=$SNAP
 
 slots:
   dlang:


### PR DESCRIPTION
This makes the snap become classic, it's needed because with this commit dmd can access with user's filesystem 

Classic confinement requires manual approval in the Snap Store, which I have a request up for here: 